### PR TITLE
Style transform internal API

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -6,15 +6,6 @@ function getID() {
   return `✨${count++}`.toString(16)
 }
 
-// function hash(s){
-//   return s.split("").reduce(function(a,b){a=((a<<5)-a)+b.charCodeAt(0);return a&a},0);              
-// }
-function hash(s) {
-    for(var i = 0, h = 0; i < s.length; i++)
-        h = Math.imul(31, h) + s.charCodeAt(i) | 0;
-    return h;
-}
-
 export default function Enhancer(options={}) {
   const {
     initialState={},
@@ -37,14 +28,13 @@ export default function Enhancer(options={}) {
     const templates = fragment(templateNames
       .map(name => {
         const renderedFragment = renderTemplate({ name, elements, store })
-        const { scriptNodes, /*styleNodes,*/ transformedFragment }  = applyTransforms({
+        const { scriptNodes, transformedFragment }  = applyTransforms({
           fragment: renderedFragment,
           scriptTransforms,
           styleTransforms,
           name
         })
         appendNodes(body, scriptNodes)
-        // appendNodes(head, styleNodes)
         return template({ fragment: transformedFragment, name})
       }).join('')
     )
@@ -62,18 +52,6 @@ export default function Enhancer(options={}) {
       }
     }
     
-
-    // collectedStyles.flat().forEach(s => {
-    //   const styleString = s.childNodes[0].value
-
-
-    //   const fingerprint = hash(s.childNodes[0].value)
-    //   deduped[fingerprint] = s
-    // })
-    // const dedupedStyles = Object.values(deduped)
-
-
-
     appendChildNodes(body, templates)
     if (authoredTemplates) {
       const ats = fragment(authoredTemplates.join(''))
@@ -369,15 +347,10 @@ function applyTransforms({ fragment, name, scriptTransforms, styleTransforms }) 
 
 
   scriptNodes.forEach(s => fragment.childNodes.splice(fragment.childNodes.indexOf(s), 1))
-  // const filteredStyleNodes = styleNodes.filter(s => s.attrs.find(attr => attr.name === 'scope')?.value === 'global')
-  // filteredStyleNodes.forEach(s => fragment.childNodes.splice(fragment.childNodes.indexOf(s), 1))
-  // styleNodes.forEach((s) => { if (!s) {fragment.childNodes.splice(fragment.childNodes.indexOf(s), 1) } }) 
 
   return {
     transformedFragment: fragment,
     scriptNodes,
-    // styleNodes: filteredStyleNodes
-    // styleNodes
   }
 }
 

--- a/test/enhance.test.mjs
+++ b/test/enhance.test.mjs
@@ -754,7 +754,8 @@ test('should run style transforms', t => {
 <!DOCTYPE html>
 <html>
 <head>
-<style scope="global">
+<style>
+  
   :host {
     display: block;
   }
@@ -762,15 +763,15 @@ test('should run style transforms', t => {
   my-transform-style styles
   context: markup
   */
-</style>
-<style scope="component">
-  :slot {
+ 
+ :slot {
     display: inline-block;
   }
   /*
   my-transform-style styles
   context: markup
   */
+
 </style>
 </head>
 <body>
@@ -801,7 +802,6 @@ test('should run style transforms', t => {
 </html>
   `
 
-  console.log(actual)
   t.equal(strip(actual), strip(expected), 'ran style transform style')
   t.end()
 })
@@ -836,16 +836,14 @@ test('should not add duplicated style tags to head', t => {
 <!DOCTYPE html>
 <html>
 <head>
-<style scope="global">
-  :host {
+<style>
+:host {
     display: block;
   }
   /*
   my-transform-style styles
   context: markup
   */
-</style>
-<style scope="component">
   :slot {
     display: inline-block;
   }
@@ -853,6 +851,7 @@ test('should not add duplicated style tags to head', t => {
   my-transform-style styles
   context: markup
   */
+  
 </style>
 </head>
 <body>
@@ -886,8 +885,7 @@ test('should not add duplicated style tags to head', t => {
 </html>
   `
 
-  console.log(actual)
-  t.equal(strip(actual), strip(expected), 'ran style transform style')
+  t.equal(strip(actual), strip(expected), 'removed duplicate style sheet')
   t.end()
 })
 test('should respect as attribute', t => {

--- a/test/enhance.test.mjs
+++ b/test/enhance.test.mjs
@@ -733,11 +733,13 @@ test('should run style transforms', t => {
       'my-transform-style': MyTransformStyle
     },
     styleTransforms: [
-      function({ attrs, raw, tagName }) {
+      function ({ attrs, raw, tagName, context }) {
+        if  (attrs.find(i=>i.name==="scope")?.value==="global"&&context==="template") return ''
         return `
         ${raw}
         /*
         ${tagName} styles
+        context: ${context}
         */
         `
 
@@ -758,6 +760,16 @@ test('should run style transforms', t => {
   }
   /*
   my-transform-style styles
+  context: markup
+  */
+</style>
+<style scope="component">
+  :slot {
+    display: inline-block;
+  }
+  /*
+  my-transform-style styles
+  context: markup
   */
 </style>
 </head>
@@ -780,6 +792,7 @@ test('should run style transforms', t => {
   }
   /*
   my-transform-style styles
+  context: template
   */
 </style>
 <h1>My Transform Style</h1>
@@ -788,10 +801,95 @@ test('should run style transforms', t => {
 </html>
   `
 
+  console.log(actual)
   t.equal(strip(actual), strip(expected), 'ran style transform style')
   t.end()
 })
 
+test('should not add duplicated style tags to head', t => {
+  const html = enhance({
+    elements: {
+      'my-transform-style': MyTransformStyle,
+    },
+    styleTransforms: [
+      function ({ attrs, raw, tagName, context }) {
+        // if tagged as global only add to the head
+        if  (attrs.find(i=>i.name==="scope")?.value==="global"&&context==="template") return ''
+
+        return `
+        ${raw}
+        /*
+        ${tagName} styles
+        context: ${context}
+        */
+        `
+
+      }
+    ]
+  })
+  const actual = html`
+  ${Head()}
+  <my-transform-style></my-transform-style>
+  <my-transform-style></my-transform-style>
+  `
+  const expected = `
+<!DOCTYPE html>
+<html>
+<head>
+<style scope="global">
+  :host {
+    display: block;
+  }
+  /*
+  my-transform-style styles
+  context: markup
+  */
+</style>
+<style scope="component">
+  :slot {
+    display: inline-block;
+  }
+  /*
+  my-transform-style styles
+  context: markup
+  */
+</style>
+</head>
+<body>
+<my-transform-style>
+  <h1>My Transform Style</h1>
+</my-transform-style>
+<my-transform-style>
+  <h1>My Transform Style</h1>
+</my-transform-style>
+<script type="module">
+  class MyTransformStyle extends HTMLElement {
+    constructor() {
+      super()
+    }
+  }
+  customElements.define('my-transform-style', MyTransformStyle)
+</script>
+<template id="my-transform-style-template">
+<style scope="component">
+  :slot {
+    display: inline-block;
+  }
+  /*
+  my-transform-style styles
+  context: template
+  */
+</style>
+<h1>My Transform Style</h1>
+</template>
+</body>
+</html>
+  `
+
+  console.log(actual)
+  t.equal(strip(actual), strip(expected), 'ran style transform style')
+  t.end()
+})
 test('should respect as attribute', t => {
   const html = enhance({
     elements: {


### PR DESCRIPTION
This PR changes the internal API for enhance style transforms. It makes the following changes:
1. Adds a `context` property to the internal API so that the style transform knows if it was called from a template or from in the SSR markup
2. Runs the SSR style transform from in the `processCustomElements` function and collects the resulting styles to be added to the head. 
   - This allows for instance and component unique styles if needed.
   - Users write styles as if they are targeting the shadowDOM and these tags can be transformed to work with the lightDOM for SSR.
   - These styles are processed with `context="markup"` so that the style transform script knows that the output should be global css rather than css in a shadowDOM.
3. The collected styles for SSR are deduplicated and merged into one `<style>` tag added to the document head.
