### PR TITLE
Make stripping slots from markup optional

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -232,8 +232,10 @@ function fillSlots(node, template, stripSlotsFromMarkup) {
     }
   }
 
-  const unusedSlots = slots.filter(slot => !usedSlots.includes(slot))
-  replaceSlots(template, unusedSlots)
+  if (stripSlotsFromMarkup) {
+    const unusedSlots = slots.filter(slot => !usedSlots.includes(slot))
+    replaceSlots(template, unusedSlots)
+  }
   const nodeChildNodes = node.childNodes
   nodeChildNodes.splice(
     0,


### PR DESCRIPTION
Allows the user to choose whether enhance should strip slots out of their markup or leave them as is.