### PR TITLE
Hoist CSS `@import` statements

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -95,11 +95,11 @@ export default function Enhancer(options={}) {
       }, { })
       const mergedCss = Object.keys(uniqueStyles)
       mergedCss.sort((a, b) => {
-        const aStart = a.trim().substring(0,7);
-        const bStart = b.trim().substring(0,7);
+        const aStart = a.trim().substring(0,7)
+        const bStart = b.trim().substring(0,7)
         if (aStart === '@import' && bStart !== '@import') return -1
         if (aStart !== '@import' && bStart === '@import') return 1
-        return 0;
+        return 0
       })
       const mergedCssString = mergedCss.join('\n')
       const mergedStyles = mergedCssString? `<style>${mergedCssString}</style>`:''

--- a/index.mjs
+++ b/index.mjs
@@ -93,7 +93,15 @@ export default function Enhancer(options={}) {
         }
         return {...acc}
       }, { })
-      const mergedCssString  = Object.keys(uniqueStyles).join('\n')
+      const mergedCss = Object.keys(uniqueStyles)
+      mergedCss.sort((a, b) => {
+        const aStart = a.trim().substring(0,7);
+        const bStart = b.trim().substring(0,7);
+        if (aStart === '@import' && bStart !== '@import') return -1
+        if (aStart !== '@import' && bStart === '@import') return 1
+        return 0;
+      })
+      const mergedCssString = mergedCss.join('\n')
       const mergedStyles = mergedCssString? `<style>${mergedCssString}</style>`:''
       if (mergedStyles) {
         const stylesNodeHead = [fragment(mergedStyles).childNodes[0]]

--- a/test/enhance.test.mjs
+++ b/test/enhance.test.mjs
@@ -21,6 +21,8 @@ import MyExternalScript from './fixtures/templates/my-external-script.mjs'
 import MyInstanceID from './fixtures/templates/my-instance-id.mjs'
 import MyContextParent from './fixtures/templates/my-context-parent.mjs'
 import MyContextChild from './fixtures/templates/my-context-child.mjs'
+import MyStyleImportFirst from './fixtures/templates/my-style-import-first.mjs'
+import MyStyleImportSecond from './fixtures/templates/my-style-import-second.mjs'
 
 function Head() {
   return `
@@ -895,4 +897,38 @@ test('should supply context', t => {
   )
   t.end()
 
+})
+
+test('should hoist css imports', t => {
+  const html = enhance({
+    elements: {
+      'my-style-import-first': MyStyleImportFirst,
+      'my-style-import-second': MyStyleImportSecond
+    }
+  })
+  const actual = html`
+  ${Head()}
+  <my-style-import-first></my-style-import-first>
+  <my-style-import-second></my-style-import-second>
+  `
+
+  const expected = `
+  <!DOCTYPE html>
+  <html>
+  <head>
+  <style>
+  @import 'my-style-import-first.css';
+  @import 'my-style-import-second.css';
+  my-style-import-first { display: block }
+  my-style-import-second { display: block }
+  </style> 
+  </head>
+  <body>
+  <my-style-import-first></my-style-import-first>
+  <my-style-import-second></my-style-import-second>
+  </body>
+  </html>
+  `
+  t.equal(strip(actual), strip(expected), 'Properly hoists CSS imports')
+  t.end()
 })

--- a/test/fixtures/templates/my-style-import-first.mjs
+++ b/test/fixtures/templates/my-style-import-first.mjs
@@ -1,0 +1,6 @@
+export default function MyStyleImportFirst({ html }) {
+  return html`
+<style>@import 'my-style-import-first.css';</style>
+<style>my-style-import-first { display: block }</style>
+  `
+}

--- a/test/fixtures/templates/my-style-import-second.mjs
+++ b/test/fixtures/templates/my-style-import-second.mjs
@@ -1,0 +1,6 @@
+export default function MyStyleImportSecond({ html }) {
+  return html`
+<style>@import 'my-style-import-second.css';</style>
+<style>my-style-import-second { display: block }</style>
+  `
+}


### PR DESCRIPTION
In order to support the full use of `@import` in CSS, those statements need to be placed at the top as they are ignored when they come after "regular" CSS statements.