### PR TITLE
Collect `<link/>` elements from custom elements and move them to `<head>`

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -19,6 +19,7 @@ export default function Enhancer(options={}) {
   function processCustomElements({ node }) {
     const collectedStyles = []
     const collectedScripts = []
+    const collectedLinks = []
     const context = {}
     const find = (node) => {
       for (const child of node.childNodes) {
@@ -31,7 +32,8 @@ export default function Enhancer(options={}) {
             const {
               frag:expandedTemplate,
               styles:stylesToCollect,
-              scripts:scriptsToCollect
+              scripts:scriptsToCollect,
+              links:linksToCollect
             } = expandTemplate({
               node: child,
               elements,
@@ -45,6 +47,7 @@ export default function Enhancer(options={}) {
             })
             collectedScripts.push(scriptsToCollect)
             collectedStyles.push(stylesToCollect)
+            collectedLinks.push(linksToCollect)
             fillSlots(child, expandedTemplate)
           }
         }
@@ -57,7 +60,8 @@ export default function Enhancer(options={}) {
 
     return {
       collectedStyles,
-      collectedScripts
+      collectedScripts,
+      collectedLinks
     }
   }
 
@@ -68,7 +72,8 @@ export default function Enhancer(options={}) {
     const head = html.childNodes.find(node => node.tagName === 'head')
     const {
       collectedStyles,
-      collectedScripts
+      collectedScripts,
+      collectedLinks
     } = processCustomElements({ node: body })
     if (collectedScripts.length) {
       const uniqueScripts = collectedScripts.flat().reduce((acc, script) => {
@@ -100,6 +105,19 @@ export default function Enhancer(options={}) {
         appendNodes(head, stylesNodeHead)
       }
     }
+    if (collectedLinks.length) {
+      const uniqueLinks = collectedLinks.flat().reduce((acc, link) => {
+        if (link) {
+          return {
+            ...acc,
+            [normalizeLinkHtml(link)]: link
+          }
+        }
+        return {...acc}
+      }, {})
+
+      appendNodes(head, Object.values(uniqueLinks))
+    }
 
     return (bodyContent
       ? serializeOuter(body.childNodes[0])
@@ -128,6 +146,7 @@ function expandTemplate({ node, elements, state, styleTransforms, scriptTransfor
   }) || ''
   const styles= []
   const scripts = []
+  const links = []
   for (const node of frag.childNodes) {
     if (node.nodeName === 'script') {
       frag.childNodes.splice(frag.childNodes.indexOf(node), 1)
@@ -143,8 +162,27 @@ function expandTemplate({ node, elements, state, styleTransforms, scriptTransfor
         styles.push(transformedStyle)
       }
     }
+    if (node.nodeName === 'link') {
+      frag.childNodes.splice(frag.childNodes.indexOf(node), 1)
+      links.push(node)
+    }
   }
-  return { frag, styles, scripts }
+  return { frag, styles, scripts, links }
+}
+
+function normalizeLinkHtml(node) {
+  const attrs = Array.from(node.attrs)
+    .sort((a, b) => {
+      if (a.name < b.name) {
+        return -1;
+      } else if (b.name < a.name) {
+        return 1
+      }
+      return 0
+    })
+    .map(attr => `${attr.name}="${attr.value}"`)
+  
+  return `<link ${attrs.join(' ')} />`
 }
 
 function renderTemplate({ name, elements, attrs=[], state={} }) {

--- a/test/enhance.test.mjs
+++ b/test/enhance.test.mjs
@@ -21,6 +21,8 @@ import MyExternalScript from './fixtures/templates/my-external-script.mjs'
 import MyInstanceID from './fixtures/templates/my-instance-id.mjs'
 import MyContextParent from './fixtures/templates/my-context-parent.mjs'
 import MyContextChild from './fixtures/templates/my-context-child.mjs'
+import MyLinkNodeFirst from './fixtures/templates/my-link-node-first.mjs'
+import MyLinkNodeSecond from './fixtures/templates/my-link-node-second.mjs'
 
 function Head() {
   return `
@@ -895,4 +897,40 @@ test('should supply context', t => {
   )
   t.end()
 
+})
+
+test('move link elements to head', t=> {
+  const html = enhance({
+    elements: {
+      'my-link-node-first': MyLinkNodeFirst,
+      'my-link-node-second': MyLinkNodeSecond
+    }
+  })
+  const actual = html`
+${Head()}
+<my-link-node-first>first</my-link-node-first>
+<my-link-node-second>second</my-link-node-second>
+<my-link-node-first>first again</my-link-node-first>
+`
+  const expected = `
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="my-link-node-first.css">
+<link rel="stylesheet" href="my-link-node-second.css">
+</head>
+<body>
+<my-link-node-first>first</my-link-node-first>
+<my-link-node-second>second</my-link-node-second>
+<my-link-node-first>first again</my-link-node-first>
+</body>
+</html>
+`
+
+  t.equal(
+    strip(actual),
+    strip(expected),
+    'moves deduplicated link elements to the head'
+  )
+  t.end()
 })

--- a/test/fixtures/templates/my-link-node-first.mjs
+++ b/test/fixtures/templates/my-link-node-first.mjs
@@ -1,0 +1,6 @@
+export default function MyLinkNodeFirst({ html }) {
+  return html`
+<link rel="stylesheet" href="my-link-node-first.css"/>
+<slot></slot>
+  `
+}

--- a/test/fixtures/templates/my-link-node-second.mjs
+++ b/test/fixtures/templates/my-link-node-second.mjs
@@ -1,0 +1,7 @@
+export default function MyLinkNodeSecond({ html }) {
+  return html`
+<link href="my-link-node-second.css" rel="stylesheet"/>
+<link rel="stylesheet" href="my-link-node-second.css"/>
+<slot></slot>
+  `
+}


### PR DESCRIPTION
Enables the use case where custom elements use the `<link/>` element to load, prefetch, preconnect, etc to external resources.

- `<link/>` elements are collected and deduplicated as are `<style>` and `<script>` elements.
- Deduplication is done by generating the element's HTML after sorting the attributes and using that HTML as the key in the collection object, ensuring that the order of the attributes makes no difference