### PR TITLE
WIP: Remove nanoID dependency for WASM compatibility

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -2,9 +2,9 @@ import { parse, fragment, serialize, serializeOuter } from '@begin/parse5'
 import isCustomElement from './lib/is-custom-element.mjs'
 import { encode, decode } from './lib/transcode.mjs'
 import walk from './lib/walk.mjs'
-import { customAlphabet } from 'nanoid'
-const alphabet = '0123456789abcdefghijklmnopqrstuvwxyz';
-const nanoid = customAlphabet(alphabet, 7);
+// import { customAlphabet } from 'nanoid'
+// const alphabet = '0123456789abcdefghijklmnopqrstuvwxyz';
+// const nanoid = customAlphabet(alphabet, 7);
 
 export default function Enhancer(options={}) {
   const {
@@ -12,7 +12,8 @@ export default function Enhancer(options={}) {
     elements=[],
     scriptTransforms=[],
     styleTransforms=[],
-    uuidFunction=nanoid,
+    // uuidFunction=nanoid,
+    uuidFunction=()=>Math.random().toString(36).substring(2,20),
     bodyContent=false,
     enhancedAttr=true
   } = options


### PR DESCRIPTION
Currently, this is a temporary hack to remove NanoId as a dependency. It is not required for a secure token or anything that requires a cryptographically solid random number. A better solution should be implemented. 

Another temporary option to match the UUID format is:
```javascript
export default function uuid() {
  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
    var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
    return v.toString(16);
  });
}
console.log(uuid())
```
